### PR TITLE
TESTS: Squash of multiple commits

### DIFF
--- a/opan/error.py
+++ b/opan/error.py
@@ -135,8 +135,8 @@ class OpanError(Exception, metaclass=_EnumIterMeta):
         ## end if
 
         # Quick RegEx to extract the name of the subclass.
-        self.subclass_name = re.search(self.__module__ + "\\.(?P<cls>\w+)'",
-                    str(self.__class__), re.I).group("cls")
+        self.subclass_name = re.search("^(?P<cls>[^(]+)\\(", repr(self)) \
+                        .group("cls")
 
         # Check for valid typecode and throw a more descriptive error if
         #  invalid.

--- a/opan/grad.py
+++ b/opan/grad.py
@@ -572,14 +572,6 @@ class OrcaEngrad(SuperOpanGrad):
                             .format(atom_count), srcstr)
                 ## end try
 
-                # Now check whether the successfully converted atomic
-                #  number is in the valid range (should be a redundant check.)
-                if not (CIC.MIN_ATOMIC_NUM <= at_num <= CIC.MAX_ATOMIC_NUM):
-                    raise GradError(GradError.GEOMBLOCK,
-                            "Atom #{0} is an unsupported element"
-                            .format(atom_count), srcstr)
-                ## end if
-
                 # Tag on the new symbol
                 self.atom_syms.append(line_mch.group("at").upper())
             ## end if

--- a/opan/test/__init__.py
+++ b/opan/test/__init__.py
@@ -24,7 +24,8 @@
 
 from __future__ import absolute_import
 
-__all__ = ['opan_utils_base', 'opan_utils_inertia', 'opan_xyz',
+__all__ = ['opan_utils_base', 'opan_utils_inertia', 'opan_utils_decorate',
+           'opan_xyz',
            'opan_error', 'opan_const', 'opan_supers',
            'orca_engrad', 'orca_hess', 'utils']
 

--- a/opan/test/opan_const.py
+++ b/opan/test/opan_const.py
@@ -30,6 +30,12 @@ class TestOpanEnumValueCheck(unittest.TestCase):
         # Representative value in a representative Enum
         self.assertTrue(EDD.NEGATIVE in EDD)
 
+    def test_OpanEnum_IterCheck(self):
+        from opan.const import EnumDispDirection as EDD
+
+        self.assertSetEqual({'NEGATIVE', 'NO_DISP', 'POSITIVE'},
+                            set(k for k in EDD))
+
 
 def suite():
     s = unittest.TestSuite()

--- a/opan/test/opan_utils_base.py
+++ b/opan/test/opan_utils_base.py
@@ -22,7 +22,7 @@
 import unittest
 
 
-class TestOpanUtilsBase(unittest.TestCase):
+class TestOpanUtilsBaseMisc(unittest.TestCase):
 
     def test_Utils_PackTupsGoodPacking(self):
         from opan.utils import pack_tups
@@ -52,6 +52,11 @@ class TestOpanUtilsBase(unittest.TestCase):
         a = np.array(range(5))
         self.assertRaises(TypeError, scast, a, np.float_)
 
+    def test_Utils_SafeCastIntToFloat(self):
+        from opan.utils import safe_cast as scast
+        v = scast(1, float)
+        self.assertIsInstance(v, float)
+
     def test_Utils_MakeTimeStampSecs(self):
         from opan.utils import make_timestamp as mt
         self.assertEqual(mt(5), "0h 0m 5s")
@@ -68,9 +73,211 @@ class TestOpanUtilsBase(unittest.TestCase):
         from opan.utils import make_timestamp as mt
         self.assertEqual(mt(200000), "55h 33m 20s")
 
+    def test_Utils_DeltaFxn(self):
+        from opan.utils import delta_fxn as dfx
+
+        self.assertEqual(dfx(1,1), 1)
+        self.assertEqual(dfx(1,2), 0)
+
+
+class TestOpanUtilsBaseCheckGeom(unittest.TestCase):
+    import numpy as np
+
+    coords = np.array(range(12))
+    atoms = ['H', 'O', 'O', 'H']
+
+    def test_Utils_CheckGeom_GoodCheck(self):
+        from opan.utils import check_geom as cg
+
+        # check_geom returns a tuple; success or not is the first element
+        self.assertTrue(cg(self.coords, self.atoms,
+                           self.coords, self.atoms)[0])
+
+    def test_Utils_CheckGeom_ArgsNotVectors(self):
+        from opan.utils import check_geom as cg
+        import numpy as np
+
+        self.assertRaises(ValueError, cg,
+                          self.coords.reshape((3,4)), self.atoms,
+                          self.coords, self.atoms)
+        self.assertRaises(ValueError, cg,
+                          self.coords, np.array(self.atoms).reshape((2,2)),
+                          self.coords, self.atoms)
+        self.assertRaises(ValueError, cg,
+                          self.coords, self.atoms,
+                          self.coords.reshape((3, 4)), self.atoms)
+        self.assertRaises(ValueError, cg,
+                          self.coords, self.atoms,
+                          self.coords, np.array(self.atoms).reshape((2, 2)))
+
+    def test_Utils_CheckGeom_CoordAtomSizeMismatch(self):
+        from opan.utils import check_geom as cg
+
+        self.assertRaises(ValueError, cg,
+                          self.coords, self.atoms,
+                          self.coords[:-1], self.atoms)
+        self.assertRaises(ValueError, cg,
+                          self.coords[:-1], self.atoms,
+                          self.coords, self.atoms)
+
+    def test_Utils_CheckGeom_GeomSizeMismatch(self):
+        from opan.utils import check_geom as cg
+
+        tup = cg(self.coords, self.atoms, self.coords[:9], self.atoms[:3])
+
+        self.assertFalse(tup[0])
+        self.assertEqual(tup[1], 'coord_dim_mismatch')
+        self.assertIsNone(tup[2])
+
+    def test_Utils_CheckGeom_CoordMismatch(self):
+        from opan.utils import check_geom as cg
+
+        # Change one of the coordinates to achieve mismatch
+        coord_mod = self.coords.copy()
+        coord_mod[0] = -12
+
+        # Store the call result and check its contents
+        tup = cg(coord_mod, self.atoms, self.coords, self.atoms)
+        self.assertFalse(tup[0])
+        self.assertEqual(tup[1], 'coord_mismatch')
+        self.assertFalse(tup[2][0])
+        self.assertTrue(all(tup[2][1:]))
+
+    def test_Utils_CheckGeom_AtomMismatch(self):
+        from opan.utils import check_geom as cg
+
+        # Change one of the atoms to achieve mismatch
+        atoms_mod = self.atoms.copy()
+        atoms_mod[2] = 'C'
+
+        # Store the call result and check its contents
+        tup = cg(self.coords, atoms_mod, self.coords, self.atoms)
+        self.assertFalse(tup[0])
+        self.assertEqual(tup[1], 'atom_mismatch')
+        self.assertFalse(tup[2][2])
+        self.assertTrue(all(tup[2][:2]))
+        self.assertTrue(tup[2][3])
+
+
+class TestOpanUtilsBaseTemplateSubst(unittest.TestCase):
+    from textwrap import dedent
+
+    template = dedent("""\
+        This <NOUN> is a two-line string.
+        It has <NUM> tags (maybe).
+        """)
+    subst_widget_four = dedent("""\
+        This widget is a two-line string.
+        It has four tags (maybe).
+        """)
+
+    dict_widget_four = {'NOUN' : 'widget',
+                        'NUM' : 'four'}
+
+    def test_Utils_TemplateSubst_GoodSubst(self):
+        from opan.utils import template_subst as ts
+
+        self.assertEqual(self.subst_widget_four,
+                ts(self.template, self.dict_widget_four))
+
+
+class TestOpanUtilsBaseAssertNPFArray(unittest.TestCase):
+
+    from opan.error import OpanError
+    from opan.test.utils import assertErrorAndTypecode
+
+    class TestError(OpanError):
+        NONE = 'NONE'
+        NOT_FLOAT = 'NOT_FLOAT'
+        NOT_ARRAY = 'NOT_ARRAY'
+        NO_MEMBER = 'NO_MEMBER'
+
+    def test_Utils_AssertNPFArray_TestObjIs1DFloatArray(self):
+        import numpy as np
+        from opan.utils import assert_npfloatarray as a_npfa
+
+        try:
+            a_npfa(np.float_(np.array(range(5))), None, "1D Float array",
+                    self.TestError, self.TestError.NONE,
+                    "No actual error; this should never be raised")
+        except Exception:
+            self.fail("Assertion failed on valid 1-D ndarray")
+
+    def test_Utils_AssertNPFArray_TestObjIs2DFloatArray(self):
+        import numpy as np
+        from opan.utils import assert_npfloatarray as a_npfa
+
+        try:
+            a_npfa(np.float_(np.array(range(6)).reshape((2,3))),
+                    None, "1D float array",
+                    self.TestError, self.TestError.NONE,
+                    "No actual error; this should never be raised")
+        except Exception:
+            self.fail("Assertion failed on valid 2-D ndarray")
+
+    def test_Utils_AssertNPFArray_TestObjArrayNotFloat(self):
+        import numpy as np
+        from opan.utils import assert_npfloatarray as a_npfa
+
+        self.assertErrorAndTypecode(self.TestError, a_npfa,
+                self.TestError.NOT_FLOAT,
+                np.array(range(5)), None, "1D int array",
+                self.TestError, self.TestError.NOT_FLOAT,
+                "ASSERTION FAIL: Non-float array")
+
+    def test_Utils_AssertNPFArray_TestObjNotArray(self):
+        import numpy as np
+        from opan.utils import assert_npfloatarray as a_npfa
+
+        # NumPy numeric type, but not an array
+        self.assertErrorAndTypecode(self.TestError, a_npfa,
+                self.TestError.NOT_ARRAY,
+                np.float_(5.5), None, "Bare float",
+                self.TestError, self.TestError.NOT_ARRAY,
+                "ASSERTION FAIL: Non-array")
+
+        # Non-ndarray type
+        self.assertErrorAndTypecode(self.TestError, a_npfa,
+                self.TestError.NOT_ARRAY,
+                self.TestError, None, "Bare float",
+                self.TestError, self.TestError.NOT_ARRAY,
+                "ASSERTION FAIL: Non-array")
+
+    def test_Utils_AssertNPFArray_TestVarIsFloatArray(self):
+        import numpy as np
+        from opan.utils import assert_npfloatarray as a_npfa
+
+        class TestClass(object):
+            import numpy as np
+            testvar = np.float_(np.array(range(5)))
+
+        try:
+            a_npfa(TestClass, 'testvar', "Array member",
+                    self.TestError, self.TestError.NONE,
+                    "No actual error; this should never be raised")
+        except Exception:
+            self.fail("Assertion failed on a valid ndarray member")
+
+    def test_Utils_AssertNPFArray_TestVarNotPresent(self):
+        import numpy as np
+        from opan.utils import assert_npfloatarray as a_npfa
+
+        self.assertErrorAndTypecode(self.TestError, a_npfa,
+                self.TestError.NO_MEMBER,
+                self.TestError, 'not_there', "Absent member",
+                self.TestError, self.TestError.NO_MEMBER,
+                "ASSERTION FAIL: Member not found")
+
+
 
 def suite():
-    s = unittest.TestLoader().loadTestsFromTestCase(TestOpanUtilsBase)
+    s = unittest.TestSuite()
+    tl = unittest.TestLoader()
+    s.addTests([tl.loadTestsFromTestCase(TestOpanUtilsBaseMisc),
+                tl.loadTestsFromTestCase(TestOpanUtilsBaseCheckGeom),
+                tl.loadTestsFromTestCase(TestOpanUtilsBaseTemplateSubst),
+                tl.loadTestsFromTestCase(TestOpanUtilsBaseAssertNPFArray)
+                ])
     return s
 
 

--- a/opan/test/opan_utils_decorate.py
+++ b/opan/test/opan_utils_decorate.py
@@ -1,0 +1,142 @@
+#-------------------------------------------------------------------------------
+# Name:        opan_utils_decorate
+# Purpose:     Test objects for opan.utils.decorate
+#
+# Author:      Brian Skinn
+#                bskinn@alum.mit.edu
+#
+# Created:     12 Apr 2016
+# Copyright:   (c) Brian Skinn 2016
+# License:     The MIT License; see "license.txt" for full license terms
+#                   and contributor agreement.
+#
+#       This file is part of opan (Open Anharmonic), a system for automated
+#       computation of anharmonic properties of molecular systems via wrapper
+#       calls to computational/quantum chemical software packages.
+#
+#       http://www.github.com/bskinn/opan
+#
+#-------------------------------------------------------------------------------
+
+
+import unittest
+
+
+class TestOpanUtilsDecorate(unittest.TestCase):
+
+    from opan.utils.decorate import arraysqueeze as arsq
+
+    @classmethod
+    def setUpClass(cls):
+        cls.longMessage = True
+
+    @staticmethod
+    @arsq(0)
+    def fxn_2p_1d(p1, p2):
+        return (p1, p2)
+
+    @staticmethod
+    @arsq(0,1)
+    def fxn_2p_2d(p1, p2):
+        return (p1, p2)
+
+    @staticmethod
+    @arsq(1, 'test')
+    def fxn_2p_1d_k(p1, p2, **kwargs):
+        return p1, p2, (kwargs['test'] if 'test' in kwargs else None)
+
+
+    def test_arraysqueeze_GoodPartialWrap(self):
+        import numpy as np
+
+        # Store the result for detailed checking
+        ret = self.fxn_2p_1d(1,2)
+
+        # First one needs to be an ndarray
+        self.assertIsInstance(ret[0], np.ndarray, 
+                msg="First argument not converted to ndarray")
+        self.assertTupleEqual(ret[0].shape, (1,),
+                msg="Bad ndarray size for wrapped first argument")
+        self.assertEqual(ret[0][0], 1,
+                msg="Corrupted value in wrapped first argument")
+
+        # Second one needs to still be an int
+        self.assertIsInstance(ret[1], int,
+                msg="Second argument not left as int")
+        self.assertEqual(ret[1], 2,
+                msg="Corrupted value in unmodified second argument")
+
+    def test_arraysqueeze_GoodTwoArgWrap(self):
+        import numpy as np
+
+        # Store the result for detailed checking
+        ret = self.fxn_2p_2d(1,2)
+
+        # Both need to be ndarrays
+        self.assertIsInstance(ret[0], np.ndarray,
+                msg="First argument not converted to ndarray")
+        self.assertTupleEqual(ret[0].shape, (1,),
+                msg="Bad ndarray size for wrapped first argument")
+        self.assertEqual(ret[0][0], 1,
+                msg="Corrupted value in wrapped first argument")
+
+        self.assertIsInstance(ret[1], np.ndarray,
+                msg="Second argument not converted to ndarray")
+        self.assertTupleEqual(ret[1].shape, (1,),
+                msg="Bad ndarray size for wrapped second argument")
+        self.assertEqual(ret[1][0], 2,
+                msg="Corrupted value in wrapped second argument")
+
+    def test_arraysqueeze_GoodArrayArgWrap(self):
+        import numpy as np
+        from opan.utils import pack_tups
+
+        # Store the array result for detailed checking
+        ary = np.array(range(1,9,2)).reshape((4,1))
+        ret = self.fxn_2p_1d(ary,"x")
+
+        # Confirm converted array matches expectations
+        for i,t in enumerate(pack_tups(ary, ret[0])):
+            self.assertEqual(t[0][0], t[1],
+                msg="Mismatch at position {0} (Pre: {1}; Post: {2})"
+                    .format(i, t[0][0], t[1]))
+
+    def test_arraysqueeze_GoodKeywordArgWrap(self):
+        import numpy as np
+
+        # Result function with keyword
+        ret = self.fxn_2p_1d_k(1, 2, test=3)
+
+        # Confirm that the parameters are wrapped properly
+        self.assertIsInstance(ret[1], np.ndarray,
+                msg="Second argument not converted to ndarray")
+        self.assertIsNotNone(ret[2],
+                msg="Keyword argument improperly returned as None")
+        self.assertIsInstance(ret[2], np.ndarray,
+                msg="Keyword argument not converted to ndarray")
+
+    def test_arraysqueeze_BadInitParam(self):
+
+        with self.assertRaises(ValueError,
+                    msg="Error not raised on float param index"):
+            @self.arsq(1.5)
+            def test_fxn(p1, p2):
+                pass
+
+        with self.assertRaises(ValueError,
+                    msg="Error not raised on object param index"):
+            @self.arsq(ValueError)
+            def test_fxn(p1, p2):
+                pass
+
+## end class TestOpanUtilsDecorate
+
+
+def suite():
+    s = unittest.TestLoader().loadTestsFromTestCase(TestOpanUtilsDecorate)
+    return s
+
+
+if __name__ == '__main__':  # pragma: no cover
+    print("Module not executable.")
+

--- a/opan/tests.py
+++ b/opan/tests.py
@@ -67,7 +67,9 @@ if __name__ == '__main__':
     SUPERS = 'supers'
     UTILS = 'utils'
     UTILS_BASE = 'utils_base'
+    UTILS_DECORATE = 'utils_decorate'
     UTILS_INERTIA = 'utils_inertia'
+    UTILS_VECTOR = 'utils_vector'
     XYZ = 'xyz'
     XYZ_FILEDATA = 'xyz_filedata'
     XYZ_DIRECTDATA = 'xyz_directdata'
@@ -121,6 +123,8 @@ if __name__ == '__main__':
             action='store_true', help="Run opan.utils.base tests")
     gp_utils.add_argument(PFX.format(UTILS_INERTIA),
             action='store_true', help="Run opan.utils.inertia tests")
+    gp_utils.add_argument(PFX.format(UTILS_DECORATE),
+            action='store_true', help="Run opan.utils.decorate tests")
 
     # ====  XYZ  ==== #
     gp_xyz.add_argument(PFX.format(XYZ),
@@ -168,6 +172,10 @@ if __name__ == '__main__':
     # opan.utils.inertia
     if any_params(params, [ALL, UTILS, UTILS_INERTIA]):
         TestMasterSuite.addTest(opan.test.opan_utils_inertia.suite())
+
+    # opan.utils.decorate
+    if any_params(params, [ALL, UTILS, UTILS_DECORATE]):
+        TestMasterSuite.addTest(opan.test.opan_utils_decorate.suite())
 
     # opan.xyz (file data)
     if any_params(params, [ALL, XYZ, XYZ_FILEDATA]):

--- a/opan/utils/base.py
+++ b/opan/utils/base.py
@@ -479,7 +479,7 @@ def template_subst(template, subs, delims=('<', '>')):
     subst_text = template
 
     # Iterate over subs and perform the .replace() calls
-    for (k,v) in subs:
+    for (k,v) in subs.items():
         subst_text = subst_text.replace(
                 delims[0] + k + delims[1], v)
     ## next tup
@@ -596,6 +596,10 @@ def assert_npfloatarray(obj, varname, desc, exc, tc, errsrc):
         dt = var.dtype
     except AttributeError:
         raise exc(tc, "'{0}' is not an np.array (lacks a 'dtype' member)"
+                    .format(desc), errsrc)
+    else:
+        if len(var.shape) < 1:
+            raise exc(tc, "'{0}' is not an np.array ('len(shape)' < 1)"
                     .format(desc), errsrc)
     ## end try
 


### PR DESCRIPTION
-1-
TESTS: Complete OrcaEngrad, add file for decorate

-2-
TESTS: Add framework for utils.decorate tests

-3-
TESTS: First arraysqueeze test added

-4-
TESTS: More tests added for arraysqueeze

utils.decorate.arraysqueeze, that is.

-5-
TESTS: Complete test set for arraysqueeze.

No more tests on utils.decorate.arraysqueeze, at least for now.

-6-
TESTS: Various in const, utils.base, OrcaHess

const:
  IterCheck to hit **iter** of metaclass

utils.base:
  Successful int->float use of safe_cast
  Successful uses of delta_fxn
  First few tests of check_geom
  Modernized the suite() function

utils.decorate:
  Removed superfluous 'as cm' in context-managed .assertRaises()
   uses

orca_hess:
  Added good- and bad-data tests for an atom block holding
   an atomic number instead of atomic symbol.

-7-
TESTS: Add c/a length-mismatch check tests

-8-
TESTS: utils.check_geom completed

Except for the redundant size check to be eliminated in #77

-9-
TESTS: Complete utils.base suite

Some uncovered lines remain, which will be eliminated when the
 redundant struture check is eliminated in #77. Otherwise,
 coverage here is complete.

The RegEx used to identify the .subclass_name of an OpanError
 subclass was improved.

An additional type check was added to utils.assert_npfloatarray,
 since bare NumPy numeric types **_do**_ bear a .dtype member.
 It was thus necessary to check len(shape) < 1 to find bare values.
